### PR TITLE
l1-stack-reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15]
         # DO NOT EDIT - LANGUAGE TEST START
-        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string]
+        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l1-stack-reference]
 # DO NOT EDIT - LANGUAGE TEST END
 
     steps:

--- a/crates/rust/src/resources/mod.rs
+++ b/crates/rust/src/resources/mod.rs
@@ -1,1 +1,2 @@
+pub mod stack_reference;
 pub mod stash;

--- a/crates/rust/src/resources/stack_reference.rs
+++ b/crates/rust/src/resources/stack_reference.rs
@@ -1,0 +1,83 @@
+use crate::{
+    Context, CustomResourceOptions, InputOrOutput, Output, PulumiAny, RegisterResourceRequest,
+    ResourceRequestObjectField,
+};
+use bon::Builder;
+
+/// Input arguments used to create a [`StackReference`] resource.
+#[derive(Builder)]
+#[builder(finish_fn = build_struct)]
+pub struct StackReferenceArgs {
+    /// The name of the stack to reference in the form `organization/project/stack`.
+    #[builder(into)]
+    pub name: InputOrOutput<String>,
+}
+
+/// Output object returned from stack reference creation.
+pub struct StackReferenceResult {
+    /// Pulumi ID is the provider-assigned unique ID for this managed resource.
+    /// It is set during deployments and may be missing (unknown) during planning phases.
+    pub id: Output<String>,
+    /// Pulumi URN is the stable logical identity of this resource in the Pulumi stack.
+    pub urn: Output<String>,
+    /// All outputs from the referenced stack as a map.
+    pub outputs: Output<PulumiAny>,
+}
+
+impl StackReferenceResult {
+    /// Returns the named output from the referenced stack as an [`Output<PulumiAny>`].
+    ///
+    /// If the given name is not present in the referenced stack, the output resolves to `null`.
+    pub fn get_output(&self, key: &str) -> Output<PulumiAny> {
+        let key = key.to_string();
+        self.outputs.map(move |map| match map.0 {
+            serde_json::Value::Object(ref obj) => obj
+                .get(&key)
+                .cloned()
+                .map(PulumiAny)
+                .unwrap_or(PulumiAny(serde_json::Value::Null)),
+            _ => PulumiAny(serde_json::Value::Null),
+        })
+    }
+}
+
+/// Registers a new stack reference resource with the given unique name and arguments.
+pub fn create(ctx: &Context, name: &str, args: StackReferenceArgs) -> StackReferenceResult {
+    __create(ctx, name, args, None)
+}
+
+/// Same as [`create`], but with additional generic options that control registration behavior.
+pub fn create_with_options(
+    ctx: &Context,
+    name: &str,
+    args: StackReferenceArgs,
+    options: CustomResourceOptions,
+) -> StackReferenceResult {
+    __create(ctx, name, args, Some(options))
+}
+
+fn __create(
+    ctx: &Context,
+    name: &str,
+    args: StackReferenceArgs,
+    options: Option<CustomResourceOptions>,
+) -> StackReferenceResult {
+    let name_binding = args.name.get_output(ctx);
+    let request = RegisterResourceRequest {
+        type_: "pulumi:pulumi:StackReference".into(),
+        name: name.to_string(),
+        version: String::new(),
+        object: &[ResourceRequestObjectField {
+            name: "name".into(),
+            value: &name_binding.drop_type(),
+        }],
+        options,
+    };
+    let composite = ctx.register_resource(request);
+
+    StackReferenceResult {
+        id: composite.get_id(),
+        urn: composite.get_urn(),
+        outputs: composite.get_field("outputs"),
+    }
+}

--- a/crates/rust_language_server/src/domain_ir.rs
+++ b/crates/rust_language_server/src/domain_ir.rs
@@ -91,6 +91,12 @@ pub enum Expr {
         args: Vec<Expr>,
     },
 
+    // Stack reference output access: getOutput(ref, "key")
+    GetStackOutput {
+        resource: Box<Expr>,
+        key: Box<Expr>,
+    },
+
     // Generic
     BinaryOp {
         left: Box<Expr>,

--- a/crates/rust_language_server/src/domain_to_rust.rs
+++ b/crates/rust_language_server/src/domain_to_rust.rs
@@ -74,7 +74,7 @@ fn lower_resource(
     token: &str,
     inputs: &[(String, Expr)],
 ) -> Result<RustStatement> {
-    let (module_path, struct_name) =
+    let (module_path, struct_name, wrap_inputs) =
         get_full_resource_path(token).context("Failed to resolve resource token")?;
 
     // Build the args via the builder: ModulePath::TypeArgs::builder().field(val)...build_struct()
@@ -84,7 +84,11 @@ fn lower_resource(
     };
     let builder_with_fields = inputs.iter().fold(builder_start, |acc, (field, expr)| {
         let lowered = lower_expr(expr);
-        let input_val = wrap_as_pulumi_any(lowered);
+        let input_val = if wrap_inputs {
+            wrap_as_pulumi_any(lowered)
+        } else {
+            lowered
+        };
         RustExpr::MethodCall {
             receiver: Box::new(acc),
             method: field.clone(),
@@ -140,11 +144,18 @@ fn wrap_as_pulumi_any(expr: RustExpr) -> RustExpr {
     }
 }
 
-fn get_full_resource_path(token: &str) -> Result<(String, String)> {
+fn get_full_resource_path(token: &str) -> Result<(String, String, bool)> {
     match token {
+        // (module_path, struct_name, wrap_inputs_as_pulumi_any)
         "pulumi:index:Stash" => Ok((
             "pulumi_gestalt_rust::resources::stash".to_string(),
             "Stash".to_string(),
+            true,
+        )),
+        "pulumi:pulumi:StackReference" => Ok((
+            "pulumi_gestalt_rust::resources::stack_reference".to_string(),
+            "StackReference".to_string(),
+            false,
         )),
         another => bail!("Unknown resource token: {}", another),
     }
@@ -403,6 +414,12 @@ fn lower_expr(expr: &Expr) -> RustExpr {
             }
         }
         Expr::StdlibCall { func, args } => lower_stdlib_call(func, args),
+        Expr::GetStackOutput { resource, key } => RustExpr::MethodCall {
+            receiver: Box::new(lower_expr(resource)),
+            method: "get_output".to_string(),
+            type_params: vec![],
+            args: vec![RustExpr::Ref(Box::new(lower_expr(key)))],
+        },
         Expr::BinaryOp { left, op, right } => RustExpr::BinaryOp {
             left: Box::new(lower_expr(left)),
             op: bin_op_str(op),

--- a/crates/rust_language_server/src/pcl_to_domain.rs
+++ b/crates/rust_language_server/src/pcl_to_domain.rs
@@ -114,11 +114,27 @@ fn lower_resource(resource: &Resource) -> Result<Statement> {
         .collect::<Result<Vec<_>>>()
         .context("Failed to lower resource inputs")?;
     Ok(Statement::Resource {
-        name: resource.name.clone(),
+        name: escape_rust_keyword(&resource.name),
         logical_name: resource.logical_name.clone(),
         token,
         inputs,
     })
+}
+
+/// Appends `_` to names that are Rust keywords so they can be used as variable names.
+fn escape_rust_keyword(name: &str) -> String {
+    // Strict keywords that cannot be used as identifiers
+    const RUST_KEYWORDS: &[&str] = &[
+        "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
+        "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",
+        "return", "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
+        "use", "where", "while", "async", "await", "dyn",
+    ];
+    if RUST_KEYWORDS.contains(&name) {
+        format!("{}_", name)
+    } else {
+        name.to_string()
+    }
 }
 
 /// Normalises a Pulumi type token to the canonical 3-part form.
@@ -189,7 +205,7 @@ fn lower_expression(expression: &Expression) -> Result<Expr> {
             bail!("RelativeTraversalExpression not yet supported")
         }
         expression::Value::ScopeTraversalExpression(scope) => {
-            let mut expr = Expr::Variable(scope.root_name.clone());
+            let mut expr = Expr::Variable(escape_rust_keyword(&scope.root_name));
             for traverser in &scope.traversal.each {
                 match &traverser.value {
                     traverser::Value::TraverseAttr(attr) => {
@@ -509,6 +525,17 @@ fn lower_function_call(call: &FunctionCallExpression) -> Result<Expr> {
             Ok(Expr::StdlibCall {
                 func: StdlibFn::Lookup,
                 args: args_lowered()?,
+            })
+        }
+        "getOutput" => {
+            ensure_arity(&call.name, arg_count, 2)?;
+            let resource = lower_expression(&call.args[0].value)
+                .context("Failed to lower getOutput resource argument")?;
+            let key = lower_expression(&call.args[1].value)
+                .context("Failed to lower getOutput key argument")?;
+            Ok(Expr::GetStackOutput {
+                resource: Box::new(resource),
+                key: Box::new(key),
             })
         }
         _ => bail!("Unsupported stdlib function: {}", call.name),

--- a/pulumi-language-rust/language_test.go
+++ b/pulumi-language-rust/language_test.go
@@ -166,7 +166,6 @@ var expectedFailures = map[string]string{
 	"l1-config-types-object":                       "https://github.com/andrzejressel/pulumi-gestalt/issues/2037",
 	"l1-keyword-overlap":                           "https://github.com/andrzejressel/pulumi-gestalt/issues/2063",
 	"l1-proxy-index":                               "https://github.com/andrzejressel/pulumi-gestalt/issues/2066",
-	"l1-stack-reference":                           "https://github.com/andrzejressel/pulumi-gestalt/issues/2067",
 	"l2-builtin-object":                            "sdk snapshot validation for output: walk expected dir: lstat testdata/sdks/output-23.0.0: no such file or directory",
 	"l2-camel-names":                               "sdk snapshot validation for camelNames: walk expected dir: lstat testdata/sdks/camelNames-19.0.0: no such file or directory",
 	"l2-component-call-simple":                     "sdk snapshot validation for component: walk expected dir: lstat testdata/sdks/component-13.3.7: no such file or directory",

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/Cargo.toml
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pulumi-rust"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.102"
+serde_json = "1.0.140"
+pulumi_gestalt_rust = "VERSION"

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/Pulumi.yaml
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-stack-reference
+runtime: rust

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/domain.json
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/domain.json
@@ -1,0 +1,49 @@
+{
+  "statements": [
+    {
+      "Resource": {
+        "name": "ref_",
+        "logical_name": "ref",
+        "token": "pulumi:pulumi:StackReference",
+        "inputs": [
+          [
+            "name",
+            {
+              "String": "organization/other/dev"
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "Export": {
+        "name": "plain",
+        "value": {
+          "GetStackOutput": {
+            "resource": {
+              "Variable": "ref_"
+            },
+            "key": {
+              "String": "plain"
+            }
+          }
+        }
+      }
+    },
+    {
+      "Export": {
+        "name": "secret",
+        "value": {
+          "GetStackOutput": {
+            "resource": {
+              "Variable": "ref_"
+            },
+            "key": {
+              "String": "secret"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/protobuf.json
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/protobuf.json
@@ -1,0 +1,269 @@
+{
+  "nodes": [
+    {
+      "resource": {
+        "name": "ref",
+        "logicalName": "ref",
+        "token": "pulumi:pulumi:StackReference",
+        "inputs": [
+          {
+            "name": "name",
+            "value": {
+              "templateExpression": {
+                "parts": [
+                  {
+                    "literalValueExpression": {
+                      "stringValue": "organization/other/dev"
+                    },
+                    "type": {
+                      "stringType": {}
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "stringType": {}
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "outputVariable": {
+        "name": "plain",
+        "logicalName": "plain",
+        "value": {
+          "functionCallExpression": {
+            "name": "getOutput",
+            "args": [
+              {
+                "value": {
+                  "scopeTraversalExpression": {
+                    "rootName": "ref",
+                    "traversal": {
+                      "each": [
+                        {
+                          "traverseRoot": {
+                            "name": "ref"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "type": {
+                    "objectType": {
+                      "properties": {
+                        "id": {
+                          "outputType": {
+                            "stringType": {}
+                          }
+                        },
+                        "name": {
+                          "outputType": {
+                            "unionType": {
+                              "element_types": [
+                                {
+                                  "noneType": {}
+                                },
+                                {
+                                  "stringType": {}
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "outputs": {
+                          "outputType": {
+                            "mapType": {
+                              "dynamicType": {}
+                            }
+                          }
+                        },
+                        "secretOutputNames": {
+                          "outputType": {
+                            "unionType": {
+                              "element_types": [
+                                {
+                                  "mapType": {
+                                    "stringType": {}
+                                  }
+                                },
+                                {
+                                  "noneType": {}
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "urn": {
+                          "outputType": {
+                            "stringType": {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": {
+                  "composite": {}
+                }
+              },
+              {
+                "value": {
+                  "templateExpression": {
+                    "parts": [
+                      {
+                        "literalValueExpression": {
+                          "stringValue": "plain"
+                        },
+                        "type": {
+                          "stringType": {}
+                        }
+                      }
+                    ]
+                  },
+                  "type": {
+                    "stringType": {}
+                  }
+                },
+                "type": {
+                  "stringType": {}
+                }
+              }
+            ]
+          },
+          "type": {
+            "outputType": {
+              "dynamicType": {}
+            }
+          }
+        },
+        "expression_type": {
+          "dynamicType": {}
+        }
+      }
+    },
+    {
+      "outputVariable": {
+        "name": "secret",
+        "logicalName": "secret",
+        "value": {
+          "functionCallExpression": {
+            "name": "getOutput",
+            "args": [
+              {
+                "value": {
+                  "scopeTraversalExpression": {
+                    "rootName": "ref",
+                    "traversal": {
+                      "each": [
+                        {
+                          "traverseRoot": {
+                            "name": "ref"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "type": {
+                    "objectType": {
+                      "properties": {
+                        "id": {
+                          "outputType": {
+                            "stringType": {}
+                          }
+                        },
+                        "name": {
+                          "outputType": {
+                            "unionType": {
+                              "element_types": [
+                                {
+                                  "noneType": {}
+                                },
+                                {
+                                  "stringType": {}
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "outputs": {
+                          "outputType": {
+                            "mapType": {
+                              "dynamicType": {}
+                            }
+                          }
+                        },
+                        "secretOutputNames": {
+                          "outputType": {
+                            "unionType": {
+                              "element_types": [
+                                {
+                                  "mapType": {
+                                    "stringType": {}
+                                  }
+                                },
+                                {
+                                  "noneType": {}
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "urn": {
+                          "outputType": {
+                            "stringType": {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": {
+                  "composite": {}
+                }
+              },
+              {
+                "value": {
+                  "templateExpression": {
+                    "parts": [
+                      {
+                        "literalValueExpression": {
+                          "stringValue": "secret"
+                        },
+                        "type": {
+                          "stringType": {}
+                        }
+                      }
+                    ]
+                  },
+                  "type": {
+                    "stringType": {}
+                  }
+                },
+                "type": {
+                  "stringType": {}
+                }
+              }
+            ]
+          },
+          "type": {
+            "outputType": {
+              "dynamicType": {}
+            }
+          }
+        },
+        "expression_type": {
+          "dynamicType": {}
+        }
+      }
+    }
+  ],
+  "plugins": [
+    {
+      "name": "pulumi",
+      "version": "3.0.0"
+    }
+  ]
+}

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/rust_ir.json
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/rust_ir.json
@@ -1,0 +1,116 @@
+{
+  "statements": [
+    {
+      "Let": {
+        "name": "ref_",
+        "value": {
+          "FunctionCall": {
+            "path": "pulumi_gestalt_rust::resources::stack_reference::create",
+            "args": [
+              {
+                "Ref": {
+                  "Identifier": "ctx"
+                }
+              },
+              {
+                "StringLiteral": "ref"
+              },
+              {
+                "MethodCall": {
+                  "receiver": {
+                    "MethodCall": {
+                      "receiver": {
+                        "FunctionCall": {
+                          "path": "pulumi_gestalt_rust::resources::stack_reference::StackReferenceArgs::builder",
+                          "args": []
+                        }
+                      },
+                      "method": "name",
+                      "type_params": [],
+                      "args": [
+                        {
+                          "StringLiteral": "organization/other/dev"
+                        }
+                      ]
+                    }
+                  },
+                  "method": "build_struct",
+                  "type_params": [],
+                  "args": []
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "Expr": {
+        "MethodCall": {
+          "receiver": {
+            "Identifier": "ctx"
+          },
+          "method": "add_export",
+          "type_params": [],
+          "args": [
+            {
+              "StringLiteral": "plain"
+            },
+            {
+              "Ref": {
+                "MethodCall": {
+                  "receiver": {
+                    "Identifier": "ref_"
+                  },
+                  "method": "get_output",
+                  "type_params": [],
+                  "args": [
+                    {
+                      "Ref": {
+                        "StringLiteral": "plain"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Expr": {
+        "MethodCall": {
+          "receiver": {
+            "Identifier": "ctx"
+          },
+          "method": "add_export",
+          "type_params": [],
+          "args": [
+            {
+              "StringLiteral": "secret"
+            },
+            {
+              "Ref": {
+                "MethodCall": {
+                  "receiver": {
+                    "Identifier": "ref_"
+                  },
+                  "method": "get_output",
+                  "type_params": [],
+                  "args": [
+                    {
+                      "Ref": {
+                        "StringLiteral": "secret"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pulumi-language-rust/testdata/projects/l1-stack-reference/src/main.rs
+++ b/pulumi-language-rust/testdata/projects/l1-stack-reference/src/main.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+fn main() {
+    pulumi_gestalt_rust::run(pulumi_main).unwrap();
+}
+fn pulumi_main(ctx: &pulumi_gestalt_rust::Context) -> Result<()> {
+    let ref_ = pulumi_gestalt_rust::resources::stack_reference::create(
+        &ctx,
+        "ref",
+        pulumi_gestalt_rust::resources::stack_reference::StackReferenceArgs::builder()
+            .name("organization/other/dev")
+            .build_struct(),
+    );
+    ctx.add_export("plain", &ref_.get_output(&"plain"));
+    ctx.add_export("secret", &ref_.get_output(&"secret"));
+    Ok(())
+}

--- a/regenerator/language-tests.json
+++ b/regenerator/language-tests.json
@@ -22,6 +22,7 @@
     "l1-output-map",
     "l1-output-null",
     "l1-output-number",
-    "l1-output-string"
+    "l1-output-string",
+    "l1-stack-reference"
   ]
 }


### PR DESCRIPTION
2 issues:

1.
```
         +  pulumi:pulumi:Stack l1-stack-reference-test create 
            pulumi:pulumi:StackReference ref  warning: The "pulumi:pulumi:StackReference" resource type is deprecated. Update your SDK or if already up to date raise an issue at https://github.com/pulumi/pulumi/issues.
         +  pulumi:pulumi:StackReference ref create warning: The "pulumi:pulumi:StackReference" resource type is deprecated. Update your SDK or if already up to date raise an issue at https://github.com/pulumi/pulumi/issues.
         +  pulumi:pulumi:Stack l1-stack-reference-test create 
```

2. The nested outputs are a bit weird - I believe the secret test works by accident. I have to add my own test where I `to_string()` the secret to ensure that the pulumi secret bits are not included