### PR TITLE
Revert "Mergify Two-Step CI (#2139)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
 #        with:
 #          domain: ${{github.repository_owner}}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -129,6 +131,8 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -136,7 +140,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache-dependency-path: "**/go.sum"
       - run: pulumi login --local
       - name: Cache Pulumi providers
@@ -172,7 +176,7 @@ jobs:
       - run: pulumi login --local
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache-dependency-path: "**/go.sum"
       - name: Cache Pulumi providers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -182,84 +186,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-pulumi-
       - run: just test-docs-ci-flow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: git add . && git diff
-      - run: git diff --cached
-      - name: Ensure no files have changed
-        run: git add . && git diff --quiet && git diff --cached --quiet
-
-  build-wasm:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, windows-2022, macos-15]
-    steps:
-      - run: git config --system core.longpaths true
-        if: runner.os == 'Windows'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-#      - uses: testspace-com/setup-testspace@v1
-#        with:
-#          domain: ${{github.repository_owner}}
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: build-examples
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      - run: pulumi login --local
-      - name: Pull required docker images
-        if: runner.os == 'Linux'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 10
-          command: docker pull public.ecr.aws/ubuntu/ubuntu:latest
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.26.2'
-          cache-dependency-path: "**/go.sum"
-      - run: go version
-      - name: Install requirements
-        run: just install-requirements
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: just wasm-ci-flow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: git add . && git diff
-      - run: git diff --cached
-      - name: Ensure no files have changed
-        run: git add . && git diff --quiet && git diff --cached --quiet
-
-  build-c:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, windows-2022, macos-15]
-
-    steps:
-      - run: git config --system core.longpaths true
-        if: runner.os == 'Windows'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      - name: Install requirements
-        run: just install-requirements
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: pulumi login --local
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.26.2'
-          cache-dependency-path: "**/go.sum"
-      - run: just c-ci-flow
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: git add . && git diff
@@ -282,6 +208,8 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -290,7 +218,7 @@ jobs:
       - run: pulumi login --local
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache-dependency-path: "**/go.sum"
       - name: Pull required docker images
         if: runner.os == 'Linux'
@@ -308,13 +236,12 @@ jobs:
         run: git add . && git diff --quiet && git diff --cached --quiet
   
   test-pulumi-language-rust:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
         # DO NOT EDIT - LANGUAGE TEST START
-        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
+        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
 # DO NOT EDIT - LANGUAGE TEST END
 
     steps:
@@ -325,7 +252,45 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
+          cache-dependency-path: "pulumi-language-rust/go.sum"
+      - name: Install requirements
+        run: just install-requirements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: pulumi login --local
+      - run: just build-rust-bridge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: just test-language-plugin-rust-single ${{ matrix.test }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: git add . && git diff
+      - run: git diff --cached
+      - name: Ensure no files have changed
+        run: git add . && git diff --quiet && git diff --cached --quiet
+
+  test-pulumi-language-rust-macos:
+    if: startsWith(github.head_ref, 'mergify/merge-queue/') || github.ref == 'refs/heads/main'
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        # DO NOT EDIT - LANGUAGE TEST MACOS START
+        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
+# DO NOT EDIT - LANGUAGE TEST MACOS END
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.3'
           cache-dependency-path: "pulumi-language-rust/go.sum"
       - name: Install requirements
         run: just install-requirements

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,10 +236,11 @@ jobs:
         run: git add . && git diff --quiet && git diff --cached --quiet
   
   test-pulumi-language-rust:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-24.04, macos-15]
         # DO NOT EDIT - LANGUAGE TEST START
         test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
 # DO NOT EDIT - LANGUAGE TEST END
@@ -249,44 +250,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.26.3'
-          cache-dependency-path: "pulumi-language-rust/go.sum"
-      - name: Install requirements
-        run: just install-requirements
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: pulumi login --local
-      - run: just build-rust-bridge
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: just test-language-plugin-rust-single ${{ matrix.test }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: git add . && git diff
-      - run: git diff --cached
-      - name: Ensure no files have changed
-        run: git add . && git diff --quiet && git diff --cached --quiet
-
-  test-pulumi-language-rust-macos:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/') || github.ref == 'refs/heads/main'
-    runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        # DO NOT EDIT - LANGUAGE TEST MACOS START
-        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
-# DO NOT EDIT - LANGUAGE TEST MACOS END
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,6 @@ jobs:
 #        with:
 #          domain: ${{github.repository_owner}}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -131,8 +129,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -140,7 +136,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.2'
           cache-dependency-path: "**/go.sum"
       - run: pulumi login --local
       - name: Cache Pulumi providers
@@ -176,7 +172,7 @@ jobs:
       - run: pulumi login --local
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.2'
           cache-dependency-path: "**/go.sum"
       - name: Cache Pulumi providers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -186,6 +182,84 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-pulumi-
       - run: just test-docs-ci-flow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: git add . && git diff
+      - run: git diff --cached
+      - name: Ensure no files have changed
+        run: git add . && git diff --quiet && git diff --cached --quiet
+
+  build-wasm:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15]
+    steps:
+      - run: git config --system core.longpaths true
+        if: runner.os == 'Windows'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+#      - uses: testspace-com/setup-testspace@v1
+#        with:
+#          domain: ${{github.repository_owner}}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: build-examples
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - run: pulumi login --local
+      - name: Pull required docker images
+        if: runner.os == 'Linux'
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 10
+          command: docker pull public.ecr.aws/ubuntu/ubuntu:latest
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.2'
+          cache-dependency-path: "**/go.sum"
+      - run: go version
+      - name: Install requirements
+        run: just install-requirements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: just wasm-ci-flow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: git add . && git diff
+      - run: git diff --cached
+      - name: Ensure no files have changed
+        run: git add . && git diff --quiet && git diff --cached --quiet
+
+  build-c:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15]
+
+    steps:
+      - run: git config --system core.longpaths true
+        if: runner.os == 'Windows'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Install requirements
+        run: just install-requirements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: pulumi login --local
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.2'
+          cache-dependency-path: "**/go.sum"
+      - run: just c-ci-flow
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: git add . && git diff
@@ -208,8 +282,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-bin: "false"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install requirements
         run: just install-requirements
@@ -218,7 +290,7 @@ jobs:
       - run: pulumi login --local
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.2'
           cache-dependency-path: "**/go.sum"
       - name: Pull required docker images
         if: runner.os == 'Linux'
@@ -236,12 +308,13 @@ jobs:
         run: git add . && git diff --quiet && git diff --cached --quiet
   
   test-pulumi-language-rust:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-24.04, macos-15]
         # DO NOT EDIT - LANGUAGE TEST START
-        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
+        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
 # DO NOT EDIT - LANGUAGE TEST END
 
     steps:
@@ -252,45 +325,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
-          cache-dependency-path: "pulumi-language-rust/go.sum"
-      - name: Install requirements
-        run: just install-requirements
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: pulumi login --local
-      - run: just build-rust-bridge
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: just test-language-plugin-rust-single ${{ matrix.test }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: git add . && git diff
-      - run: git diff --cached
-      - name: Ensure no files have changed
-        run: git add . && git diff --quiet && git diff --cached --quiet
-
-  test-pulumi-language-rust-macos:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/') || github.ref == 'refs/heads/main'
-    runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        # DO NOT EDIT - LANGUAGE TEST MACOS START
-        test: [l1-builtin-base64, l1-builtin-cwd, l1-builtin-file, l1-builtin-info, l1-builtin-list, l1-builtin-min-max, l1-builtin-object, l1-builtin-project-root, l1-builtin-project-root-main, l1-builtin-require-pulumi-version, l1-builtin-secret, l1-builtin-sha1, l1-builtin-stash, l1-builtin-string, l1-config-secret, l1-config-types-primitive, l1-elide-index, l1-empty, l1-main, l1-output-array, l1-output-bool, l1-output-map, l1-output-null, l1-output-number, l1-output-string, l2-destroy]
-# DO NOT EDIT - LANGUAGE TEST MACOS END
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-bin: "false"
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.26.3'
+          go-version: '1.26.2'
           cache-dependency-path: "pulumi-language-rust/go.sum"
       - name: Install requirements
         run: just install-requirements

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,40 +1,11 @@
 queue_rules:
   - name: default
-    max_checks_retries: 3
+    max_checks_retries: 10
     merge_method: squash
     commit_message_template: |
       {{ title }} (#{{ number }})
         
       {{ body }}
-    merge_conditions:
-# DO NOT EDIT - MERGE CONDITIONS START
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-base64)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-cwd)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-file)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-info)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-list)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-min-max)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-object)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root-main)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-require-pulumi-version)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-secret)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-sha1)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-stash)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-string)
-      - check-success=test-pulumi-language-rust-macos (l1-config-secret)
-      - check-success=test-pulumi-language-rust-macos (l1-config-types-primitive)
-      - check-success=test-pulumi-language-rust-macos (l1-elide-index)
-      - check-success=test-pulumi-language-rust-macos (l1-empty)
-      - check-success=test-pulumi-language-rust-macos (l1-main)
-      - check-success=test-pulumi-language-rust-macos (l1-output-array)
-      - check-success=test-pulumi-language-rust-macos (l1-output-bool)
-      - check-success=test-pulumi-language-rust-macos (l1-output-map)
-      - check-success=test-pulumi-language-rust-macos (l1-output-null)
-      - check-success=test-pulumi-language-rust-macos (l1-output-number)
-      - check-success=test-pulumi-language-rust-macos (l1-output-string)
-      - check-success=test-pulumi-language-rust-macos (l2-destroy)
-# DO NOT EDIT - MERGE CONDITIONS END
 
 pull_request_rules:
   - name: automatic merge for main when CI passes
@@ -47,5 +18,3 @@ pull_request_rules:
       queue:
         name: default
 
-merge_protections_settings:
-  reporting_method: deployments

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,36 +6,6 @@ queue_rules:
       {{ title }} (#{{ number }})
         
       {{ body }}
-    merge_conditions:
-# DO NOT EDIT - MERGE CONDITIONS START
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-base64)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-cwd)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-file)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-info)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-list)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-min-max)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-object)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root-main)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-require-pulumi-version)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-secret)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-sha1)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-stash)
-      - check-success=test-pulumi-language-rust-macos (l1-builtin-string)
-      - check-success=test-pulumi-language-rust-macos (l1-config-secret)
-      - check-success=test-pulumi-language-rust-macos (l1-config-types-primitive)
-      - check-success=test-pulumi-language-rust-macos (l1-elide-index)
-      - check-success=test-pulumi-language-rust-macos (l1-empty)
-      - check-success=test-pulumi-language-rust-macos (l1-main)
-      - check-success=test-pulumi-language-rust-macos (l1-output-array)
-      - check-success=test-pulumi-language-rust-macos (l1-output-bool)
-      - check-success=test-pulumi-language-rust-macos (l1-output-map)
-      - check-success=test-pulumi-language-rust-macos (l1-output-null)
-      - check-success=test-pulumi-language-rust-macos (l1-output-number)
-      - check-success=test-pulumi-language-rust-macos (l1-output-string)
-      - check-success=test-pulumi-language-rust-macos (l2-destroy)
-# DO NOT EDIT - MERGE CONDITIONS END
-
 pull_request_rules:
   - name: automatic merge for main when CI passes
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,40 @@
 queue_rules:
   - name: default
-    max_checks_retries: 10
+    max_checks_retries: 3
     merge_method: squash
     commit_message_template: |
       {{ title }} (#{{ number }})
         
       {{ body }}
+    merge_conditions:
+# DO NOT EDIT - MERGE CONDITIONS START
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-base64)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-cwd)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-file)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-info)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-list)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-min-max)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-object)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-project-root-main)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-require-pulumi-version)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-secret)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-sha1)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-stash)
+      - check-success=test-pulumi-language-rust-macos (l1-builtin-string)
+      - check-success=test-pulumi-language-rust-macos (l1-config-secret)
+      - check-success=test-pulumi-language-rust-macos (l1-config-types-primitive)
+      - check-success=test-pulumi-language-rust-macos (l1-elide-index)
+      - check-success=test-pulumi-language-rust-macos (l1-empty)
+      - check-success=test-pulumi-language-rust-macos (l1-main)
+      - check-success=test-pulumi-language-rust-macos (l1-output-array)
+      - check-success=test-pulumi-language-rust-macos (l1-output-bool)
+      - check-success=test-pulumi-language-rust-macos (l1-output-map)
+      - check-success=test-pulumi-language-rust-macos (l1-output-null)
+      - check-success=test-pulumi-language-rust-macos (l1-output-number)
+      - check-success=test-pulumi-language-rust-macos (l1-output-string)
+      - check-success=test-pulumi-language-rust-macos (l2-destroy)
+# DO NOT EDIT - MERGE CONDITIONS END
 
 pull_request_rules:
   - name: automatic merge for main when CI passes
@@ -18,3 +47,5 @@ pull_request_rules:
       queue:
         name: default
 
+merge_protections_settings:
+  reporting_method: deployments

--- a/deploy/repository/src/github_workflow.rs
+++ b/deploy/repository/src/github_workflow.rs
@@ -34,17 +34,10 @@ impl GitHubWorkflow {
     }
 
     pub fn get_job_full_names(&self) -> Vec<String> {
-        self.get_job_full_names_excluding_prefix("")
-    }
-
-    pub fn get_job_full_names_excluding_prefix(&self, prefix: &str) -> Vec<String> {
         let mut job_names = Vec::new();
 
-        for (job_key, job) in &self.jobs {
-            if !prefix.is_empty() && job_key.starts_with(prefix) {
-                continue;
-            }
-            let job_name = job.name.clone().unwrap_or_else(|| job_key.clone());
+        for (job_name, job) in &self.jobs {
+            let job_name = job.name.clone().unwrap_or_else(|| job_name.clone());
             if let Some(matrix) = job.strategy.as_ref().and_then(|s| s.matrix.as_ref())
                 && !matrix.is_empty()
             {
@@ -157,22 +150,6 @@ jobs:
             "build-generated-provider (aws-1)",
             "build-generated-provider (cloudflare)",
             "build-generated-provider (docker)",
-        ];
-
-        assert_eq!(job_names, expected_job_names);
-    }
-
-    #[test]
-    fn test_generate_full_job_names_excluding_prefix() {
-        let workflow = GitHubWorkflow::from_yaml(YAML_CONTENT).unwrap();
-
-        let job_names = workflow.get_job_full_names_excluding_prefix("build-generated");
-
-        let expected_job_names = [
-            "Build no matrix",
-            "build-base (macos-14)",
-            "build-base (ubuntu-24.04)",
-            "build-base (windows-2022)",
         ];
 
         assert_eq!(job_names, expected_job_names);

--- a/deploy/repository/src/main.rs
+++ b/deploy/repository/src/main.rs
@@ -47,7 +47,7 @@ fn pulumi_main(ctx: &Context) -> Result<()> {
 
     let build_yaml_jobs =
         github_workflow::GitHubWorkflow::from_file("../../.github/workflows/build.yml")?
-            .get_job_full_names_excluding_prefix("test-pulumi-language-rust-macos");
+            .get_job_full_names();
     let codeql_yaml_jobs =
         github_workflow::GitHubWorkflow::from_file("../../.github/workflows/codeql.yml")?
             .get_job_full_names();

--- a/regenerator/src/main.rs
+++ b/regenerator/src/main.rs
@@ -152,8 +152,6 @@ fn main() {
     update_tests(&tests, &filtered_tests);
     update_generator_cargo_toml(&tests, &filtered_tests);
     update_github_actions_language_tests(&language_tests.tests);
-    update_github_actions_language_tests_macos(&language_tests.tests);
-    update_mergify_merge_conditions(&language_tests.tests);
     generate_proto::regenerate_proto().expect("Failed to regenerate proto");
 }
 
@@ -199,43 +197,6 @@ fn update_github_actions_language_tests(language_tests: &[String]) {
 
     fs::write(".github/workflows/build.yml", content)
         .expect("Failed to write to .github/workflows/build.yml");
-}
-
-fn update_github_actions_language_tests_macos(language_tests: &[String]) {
-    let content = fs::read_to_string(".github/workflows/build.yml")
-        .expect("Failed to read .github/workflows/build.yml");
-
-    let mut replacement = String::new();
-    replacement.push_str("        test: [");
-    replacement.push_str(&language_tests.join(", "));
-    replacement.push_str("]\n");
-
-    let start_marker = "# DO NOT EDIT - LANGUAGE TEST MACOS START";
-    let end_marker = "# DO NOT EDIT - LANGUAGE TEST MACOS END";
-    let content = replace_between_markers(&content, start_marker, end_marker, &replacement);
-
-    fs::write(".github/workflows/build.yml", content)
-        .expect("Failed to write to .github/workflows/build.yml");
-}
-
-fn update_mergify_merge_conditions(language_tests: &[String]) {
-    let content = fs::read_to_string(".mergify.yml").expect("Failed to read .mergify.yml");
-
-    let replacement = language_tests
-        .iter()
-        .map(|test| {
-            format!(
-                "      - check-success=test-pulumi-language-rust-macos ({})\n",
-                test
-            )
-        })
-        .collect::<String>();
-
-    let start_marker = "# DO NOT EDIT - MERGE CONDITIONS START";
-    let end_marker = "# DO NOT EDIT - MERGE CONDITIONS END";
-    let content = replace_between_markers(&content, start_marker, end_marker, &replacement);
-
-    fs::write(".mergify.yml", content).expect("Failed to write to .mergify.yml");
 }
 
 fn update_rust_generator_test_rs(tests: &[&str], filtered_tests: &[FilteredTest]) {


### PR DESCRIPTION
Two-step runs non-MacOS tests twice - before queue and in the queue. I think I'd rather have it the old way.